### PR TITLE
fix: Pattern without colon name does not keep.

### DIFF
--- a/__tests__/domain/general.test.ts
+++ b/__tests__/domain/general.test.ts
@@ -240,6 +240,12 @@ test('keep with variable name (pattern)', () => {
   expect(pattern.match('popsicle')).toMatchObject({ theWord: 'popsicle', '@keep': { keepTheWord: 'popsicle' } })
 })
 
+test('keep with no varname, but keep name (pattern)', () => {
+  const pattern = new Pattern('#{ word | keep keepTheWord }')
+  expect(pattern.match('hello')).toMatchObject({ '@keep': { keepTheWord: 'hello' } })
+  expect(pattern.match('popsicle')).toMatchObject({ '@keep': { keepTheWord: 'popsicle' } })
+})
+
 test('keep with no variable name with void (pattern)', () => {
   const pattern = new Pattern('#{ word : theWord | keep | void }')
   expect(pattern.match('hello')).toMatchObject({ theWord: undefined, '@keep': { theWord: 'hello' } })
@@ -250,6 +256,11 @@ test('keep with variable name and void (pattern)', () => {
   const pattern = new Pattern('#{ word : theWord | keep keepTheWord | void }')
   expect(pattern.match('hello')).toMatchObject({ theWord: undefined, '@keep': { keepTheWord: 'hello' } })
   expect(pattern.match('popsicle')).toMatchObject({ theWord: undefined, '@keep': { keepTheWord: 'popsicle' } })
+})
+test('keep with variable name (pattern no ":")', () => {
+  const pattern = new Pattern('#{ word | keep keepTheWord | void }')
+  expect(pattern.match('hello')).toMatchObject({ '@keep': { keepTheWord: 'hello' } })
+  expect(pattern.match('popsicle')).toMatchObject({ '@keep': { keepTheWord: 'popsicle' } })
 })
 
 test('keep with no variable name (template)', () => {

--- a/src/pattern/interpreter.ts
+++ b/src/pattern/interpreter.ts
@@ -4,7 +4,11 @@ import { interpretModifier } from '../common/interpreter'
 function interpretModifiable({ base, varname, modifiers }: IModifiableLeaf): IInterpret {
   const baseModifier = interpretModifier(base, varname!)
   const toolModifiers = modifiers.map((modifier) => interpretModifier(modifier, varname!))
-  return (store) => toolModifiers.reduce((store, modifier) => modifier(store), baseModifier(store))
+  return (store) => {
+    const newStore = toolModifiers.reduce((store, modifier) => modifier(store), baseModifier(store))
+    delete newStore[null!]
+    return newStore
+  }
 }
 
 export function interpret(modifiables: IModifiableLeafs): IInterpret {

--- a/src/pattern/parser.ts
+++ b/src/pattern/parser.ts
@@ -56,7 +56,7 @@ function compilePatternStaticLeaf(leaf: IStaticLeaf): string {
 }
 
 function compilePatternModifiableLeaf(leaf: IModifiableLeaf): string {
-  return 'varname' in leaf && leaf.varname !== null ? `(?<${leaf.varname}>${leaf.base.pattern})` : `(${leaf.base.pattern})`
+  return 'varname' in leaf ? `(?<${leaf.varname}>${leaf.base.pattern})` : `(${leaf.base.pattern})`
 }
 
 function compilePatternLeaf(leaf: ILeaf): string {
@@ -71,6 +71,6 @@ function compilePatternLeaf(leaf: ILeaf): string {
 export function compilePattern(ast: IAST, flags: string = ''): { pattern: RegExp; processors: IModifiableLeafs } {
   return {
     pattern: new RegExp(`^${ast.map((leaf) => compilePatternLeaf(leaf)).join('')}$`, flags),
-    processors: ast.filter((leaf) => leaf.type === LeafKind.Modifiable && leaf.varname) as IModifiableLeafs,
+    processors: ast.filter((leaf) => leaf.type === LeafKind.Modifiable) as IModifiableLeafs,
   }
 }


### PR DESCRIPTION
E.g. the pattern `#{ word | keep theWord }` would previously not execute, since `keep` wasn't able to access the value in the store. The code has been updated to run with `null` as a "valid" variable name in the store, that will be removed after each dynamic part interpretation.